### PR TITLE
Feature/columnar query api

### DIFF
--- a/priv/ducky_nif/Cargo.lock
+++ b/priv/ducky_nif/Cargo.lock
@@ -466,6 +466,7 @@ version = "0.4.0"
 dependencies = [
  "chrono",
  "duckdb",
+ "rust_decimal",
  "rustler",
 ]
 

--- a/priv/ducky_nif/Cargo.toml
+++ b/priv/ducky_nif/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 rustler = "0.37.0"
 duckdb = { version = "1.4.3", features = ["bundled"] }
 chrono = "0.4.42"
+rust_decimal = "1.39.0"
 
 [profile.release]
 lto = "fat"

--- a/priv/ducky_nif/src/lib.rs
+++ b/priv/ducky_nif/src/lib.rs
@@ -543,8 +543,8 @@ fn arrow_element_to_value_ref<'b>(
             Ok(ValueRef::UBigInt(arr.value(elem_idx)))
         }
         DataType::Float16 => {
-            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Float32Type>();
-            Ok(ValueRef::Float(arr.value(elem_idx)))
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Float16Type>();
+            Ok(ValueRef::Float(f32::from(arr.value(elem_idx))))
         }
         DataType::Float32 => {
             let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Float32Type>();
@@ -1101,49 +1101,34 @@ fn execute_statement_columns<'a>(
         return Ok(Vec::new());
     }
 
-    match stmt.query_arrow(params) {
-        Ok(mut batches) => {
-            let schema = batches.get_schema();
-            let mut columns: Vec<(String, Vec<Term<'a>>)> = schema
-                .fields()
-                .iter()
-                .map(|field| (field.name().to_string(), Vec::new()))
-                .collect();
+    let mut batches = stmt.query_arrow(params)?;
+    let schema = batches.get_schema();
+    let mut columns: Vec<(String, Vec<Term<'a>>)> = schema
+        .fields()
+        .iter()
+        .map(|field| (field.name().to_string(), Vec::new()))
+        .collect();
 
-            for batch in batches.by_ref() {
-                for column_idx in 0..batch.num_columns() {
-                    let array = batch.column(column_idx);
-                    for row_idx in 0..batch.num_rows() {
-                        let term = if array.is_null(row_idx) {
-                            atoms::null().encode(env)
-                        } else {
-                            let value =
-                                arrow_element_to_value_ref(array, row_idx).map_err(|e| {
-                                    DuckyError::DatabaseError(format!(
-                                        "Failed to convert column value: {}",
-                                        e
-                                    ))
-                                })?;
-                            value_to_term(env, value).map_err(|_| {
-                                DuckyError::DatabaseError(
-                                    "Failed to convert column value".to_string(),
-                                )
-                            })?
-                        };
-                        if let Some((_, values)) = columns.get_mut(column_idx) {
-                            values.push(term);
-                        }
-                    }
-                }
+    for batch in batches.by_ref() {
+        for column_idx in 0..batch.num_columns() {
+            let array = batch.column(column_idx);
+            for row_idx in 0..batch.num_rows() {
+                let term = if array.is_null(row_idx) {
+                    atoms::null().encode(env)
+                } else {
+                    let value = arrow_element_to_value_ref(array, row_idx).map_err(|e| {
+                        DuckyError::DatabaseError(format!("Failed to convert column value: {}", e))
+                    })?;
+                    value_to_term(env, value).map_err(|_| {
+                        DuckyError::DatabaseError("Failed to convert column value".to_string())
+                    })?
+                };
+                columns[column_idx].1.push(term);
             }
-
-            Ok(columns)
-        }
-        Err(_) => {
-            stmt.execute(params)?;
-            Ok(Vec::new())
         }
     }
+
+    Ok(columns)
 }
 
 /// Converts days since Unix epoch to ISO date string (YYYY-MM-DD).

--- a/priv/ducky_nif/src/lib.rs
+++ b/priv/ducky_nif/src/lib.rs
@@ -434,90 +434,171 @@ fn value_to_term<'a, 'b>(env: Env<'a>, value: ValueRef<'b>) -> NifResult<Term<'a
 
 /// Converts an Arrow array element to a DuckDB ValueRef.
 fn arrow_element_to_value_ref<'b>(
-    array: &'b dyn duckdb::arrow::array::Array,
+    array: &'b duckdb::arrow::array::ArrayRef,
     elem_idx: usize,
 ) -> Result<ValueRef<'b>, String> {
     use duckdb::arrow::array::AsArray;
-    use duckdb::arrow::datatypes::DataType;
-    use duckdb::types::ListType;
+    use duckdb::arrow::datatypes::{DataType, TimeUnit as ArrowTimeUnit};
+    use duckdb::types::{EnumType, ListType};
 
-    match array.data_type() {
+    let array_ref = array.as_ref();
+    if array_ref.is_null(elem_idx) {
+        return Ok(ValueRef::Null);
+    }
+
+    match array_ref.data_type() {
         DataType::Boolean => {
-            let arr = array.as_boolean();
+            let arr = array_ref.as_boolean();
             Ok(ValueRef::Boolean(arr.value(elem_idx)))
         }
         DataType::Int8 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::Int8Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Int8Type>();
             Ok(ValueRef::TinyInt(arr.value(elem_idx)))
         }
         DataType::Int16 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::Int16Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Int16Type>();
             Ok(ValueRef::SmallInt(arr.value(elem_idx)))
         }
         DataType::Int32 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::Int32Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Int32Type>();
             Ok(ValueRef::Int(arr.value(elem_idx)))
         }
         DataType::Int64 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::Int64Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Int64Type>();
             Ok(ValueRef::BigInt(arr.value(elem_idx)))
         }
         DataType::UInt8 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::UInt8Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::UInt8Type>();
             Ok(ValueRef::UTinyInt(arr.value(elem_idx)))
         }
         DataType::UInt16 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::UInt16Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::UInt16Type>();
             Ok(ValueRef::USmallInt(arr.value(elem_idx)))
         }
         DataType::UInt32 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::UInt32Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::UInt32Type>();
             Ok(ValueRef::UInt(arr.value(elem_idx)))
         }
         DataType::UInt64 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::UInt64Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::UInt64Type>();
             Ok(ValueRef::UBigInt(arr.value(elem_idx)))
         }
+        DataType::Float16 => {
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Float32Type>();
+            Ok(ValueRef::Float(arr.value(elem_idx)))
+        }
         DataType::Float32 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::Float32Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Float32Type>();
             Ok(ValueRef::Float(arr.value(elem_idx)))
         }
         DataType::Float64 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::Float64Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Float64Type>();
             Ok(ValueRef::Double(arr.value(elem_idx)))
         }
         DataType::Utf8 => {
-            let arr = array.as_string::<i32>();
+            let arr = array_ref.as_string::<i32>();
+            Ok(ValueRef::Text(arr.value(elem_idx).as_bytes()))
+        }
+        DataType::LargeUtf8 => {
+            let arr = array_ref.as_string::<i64>();
             Ok(ValueRef::Text(arr.value(elem_idx).as_bytes()))
         }
         DataType::Binary => {
-            let arr = array.as_binary::<i32>();
+            let arr = array_ref.as_binary::<i32>();
             Ok(ValueRef::Blob(arr.value(elem_idx)))
         }
+        DataType::LargeBinary => {
+            let arr = array_ref.as_binary::<i64>();
+            Ok(ValueRef::Blob(arr.value(elem_idx)))
+        }
+        DataType::Decimal128(..) => {
+            let arr = array_ref
+                .as_any()
+                .downcast_ref::<duckdb::arrow::array::Decimal128Array>()
+                .ok_or_else(|| "Failed to downcast Decimal128Array".to_string())?;
+            if arr.scale() == 0 {
+                return Ok(ValueRef::HugeInt(arr.value(elem_idx)));
+            }
+            Ok(ValueRef::Decimal(
+                rust_decimal::Decimal::from_i128_with_scale(
+                    arr.value(elem_idx),
+                    arr.scale() as u32,
+                ),
+            ))
+        }
         DataType::Struct(_) => {
-            let child_struct = array.as_struct();
+            let child_struct = array_ref.as_struct();
             Ok(ValueRef::Struct(child_struct, elem_idx))
         }
+        DataType::LargeList(_) => {
+            let child_list = array_ref.as_list::<i64>();
+            Ok(ValueRef::List(ListType::Large(child_list), elem_idx))
+        }
         DataType::List(_) => {
-            let child_list = array.as_list();
+            let child_list = array_ref.as_list::<i32>();
             Ok(ValueRef::List(ListType::Regular(child_list), elem_idx))
         }
-        DataType::Timestamp(time_unit, _) => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::TimestampMicrosecondType>();
+        DataType::Dictionary(key_type, _) => {
+            let arr = array_ref.as_any();
+            Ok(ValueRef::Enum(
+                match key_type.as_ref() {
+                    DataType::UInt8 => EnumType::UInt8(
+                        arr.downcast_ref::<duckdb::arrow::array::DictionaryArray<
+                            duckdb::arrow::datatypes::UInt8Type,
+                        >>()
+                        .ok_or_else(|| "Failed to downcast UInt8 dictionary".to_string())?,
+                    ),
+                    DataType::UInt16 => EnumType::UInt16(
+                        arr.downcast_ref::<duckdb::arrow::array::DictionaryArray<
+                            duckdb::arrow::datatypes::UInt16Type,
+                        >>()
+                        .ok_or_else(|| "Failed to downcast UInt16 dictionary".to_string())?,
+                    ),
+                    DataType::UInt32 => EnumType::UInt32(
+                        arr.downcast_ref::<duckdb::arrow::array::DictionaryArray<
+                            duckdb::arrow::datatypes::UInt32Type,
+                        >>()
+                        .ok_or_else(|| "Failed to downcast UInt32 dictionary".to_string())?,
+                    ),
+                    typ => return Err(format!("Unsupported enum key type: {:?}", typ)),
+                },
+                elem_idx,
+            ))
+        }
+        DataType::Timestamp(time_unit, _) if *time_unit == ArrowTimeUnit::Second => {
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::TimestampSecondType>();
+            let duckdb_unit = arrow_to_duckdb_time_unit(*time_unit);
+            Ok(ValueRef::Timestamp(duckdb_unit, arr.value(elem_idx)))
+        }
+        DataType::Timestamp(time_unit, _) if *time_unit == ArrowTimeUnit::Millisecond => {
+            let arr =
+                array_ref.as_primitive::<duckdb::arrow::datatypes::TimestampMillisecondType>();
+            let duckdb_unit = arrow_to_duckdb_time_unit(*time_unit);
+            Ok(ValueRef::Timestamp(duckdb_unit, arr.value(elem_idx)))
+        }
+        DataType::Timestamp(time_unit, _) if *time_unit == ArrowTimeUnit::Microsecond => {
+            let arr =
+                array_ref.as_primitive::<duckdb::arrow::datatypes::TimestampMicrosecondType>();
+            let duckdb_unit = arrow_to_duckdb_time_unit(*time_unit);
+            Ok(ValueRef::Timestamp(duckdb_unit, arr.value(elem_idx)))
+        }
+        DataType::Timestamp(time_unit, _) if *time_unit == ArrowTimeUnit::Nanosecond => {
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::TimestampNanosecondType>();
             let duckdb_unit = arrow_to_duckdb_time_unit(*time_unit);
             Ok(ValueRef::Timestamp(duckdb_unit, arr.value(elem_idx)))
         }
         DataType::Date32 => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::Date32Type>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Date32Type>();
             Ok(ValueRef::Date32(arr.value(elem_idx)))
         }
         DataType::Time64(time_unit) => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::Time64MicrosecondType>();
+            let arr = array_ref.as_primitive::<duckdb::arrow::datatypes::Time64MicrosecondType>();
             let duckdb_unit = arrow_to_duckdb_time_unit(*time_unit);
             Ok(ValueRef::Time64(duckdb_unit, arr.value(elem_idx)))
         }
         DataType::Interval(_) => {
-            let arr = array.as_primitive::<duckdb::arrow::datatypes::IntervalMonthDayNanoType>();
+            let arr =
+                array_ref.as_primitive::<duckdb::arrow::datatypes::IntervalMonthDayNanoType>();
             let interval = arr.value(elem_idx);
             Ok(ValueRef::Interval {
                 months: interval.months,
@@ -525,8 +606,23 @@ fn arrow_element_to_value_ref<'b>(
                 nanos: interval.nanoseconds,
             })
         }
+        DataType::Map(..) => {
+            let arr = array_ref
+                .as_any()
+                .downcast_ref::<duckdb::arrow::array::MapArray>()
+                .ok_or_else(|| "Failed to downcast MapArray".to_string())?;
+            Ok(ValueRef::Map(arr, elem_idx))
+        }
+        DataType::FixedSizeList(..) => {
+            let arr = array_ref
+                .as_any()
+                .downcast_ref::<duckdb::arrow::array::FixedSizeListArray>()
+                .ok_or_else(|| "Failed to downcast FixedSizeListArray".to_string())?;
+            Ok(ValueRef::Array(arr, elem_idx))
+        }
+        DataType::Union(..) => Ok(ValueRef::Union(array, elem_idx)),
         unsupported_type => Err(format!(
-            "Unsupported list element type: {:?}",
+            "Unsupported arrow element type: {:?}",
             unsupported_type
         )),
     }
@@ -570,7 +666,7 @@ fn encode_list<'a, 'b>(
         if values_array.is_null(elem_idx) {
             elements.push(atoms::null().encode(env));
         } else {
-            let value_ref = arrow_element_to_value_ref(values_array.as_ref(), elem_idx)
+            let value_ref = arrow_element_to_value_ref(values_array, elem_idx)
                 .map_err(|e| rustler::Error::Term(Box::new(e)))?;
             let term = value_to_term(env, value_ref)?;
             elements.push(term);
@@ -604,7 +700,7 @@ fn encode_struct<'a>(
             continue;
         }
 
-        match arrow_element_to_value_ref(field.as_ref(), row_idx) {
+        match arrow_element_to_value_ref(field, row_idx) {
             Ok(value_ref) => {
                 let term_value = value_to_term(env, value_ref)?;
                 map = map.map_put(field_name.encode(env), term_value)?;
@@ -656,7 +752,7 @@ fn encode_array<'a>(
         if values.is_null(elem_idx) {
             elements.push(atoms::null().encode(env));
         } else {
-            let value_ref = arrow_element_to_value_ref(values.as_ref(), elem_idx)
+            let value_ref = arrow_element_to_value_ref(&values, elem_idx)
                 .map_err(|e| rustler::Error::Term(Box::new(e)))?;
             let term = value_to_term(env, value_ref)?;
             elements.push(term);
@@ -692,7 +788,7 @@ fn encode_map<'a>(
         let key_str = if keys.is_null(idx) {
             "null".to_string()
         } else {
-            let key_ref = arrow_element_to_value_ref(keys.as_ref(), idx)
+            let key_ref = arrow_element_to_value_ref(keys, idx)
                 .map_err(|e| rustler::Error::Term(Box::new(e)))?;
             value_to_string(key_ref)
         };
@@ -701,7 +797,7 @@ fn encode_map<'a>(
         let value_term = if values.is_null(idx) {
             atoms::null().encode(env)
         } else {
-            let value_ref = arrow_element_to_value_ref(values.as_ref(), idx)
+            let value_ref = arrow_element_to_value_ref(values, idx)
                 .map_err(|e| rustler::Error::Term(Box::new(e)))?;
             value_to_term(env, value_ref)?
         };
@@ -754,7 +850,7 @@ fn encode_union<'a>(
     let value_term = if child_array.is_null(child_idx) {
         atoms::null().encode(env)
     } else {
-        match arrow_element_to_value_ref(child_array.as_ref(), child_idx) {
+        match arrow_element_to_value_ref(child_array, child_idx) {
             Ok(value_ref) => value_to_term(env, value_ref)?,
             Err(e) => return Err(rustler::Error::Term(Box::new(e))),
         }

--- a/priv/ducky_nif/src/lib.rs
+++ b/priv/ducky_nif/src/lib.rs
@@ -229,6 +229,39 @@ fn execute_prepared<'a>(
     execute_statement(env, &connection, sql, param_refs.as_slice())
 }
 
+/// Executes a prepared statement and returns column-oriented results.
+#[rustler::nif(schedule = "DirtyCpu")]
+fn execute_prepared_columns<'a>(
+    env: Env<'a>,
+    stmt: ResourceArc<StatementResource>,
+    params_list: Vec<Term<'a>>,
+) -> Result<Vec<(String, Vec<Term<'a>>)>, DuckyError> {
+    use duckdb::types::ToSql;
+
+    let sql_guard = stmt
+        .sql
+        .lock()
+        .map_err(|e| DuckyError::DatabaseError(format!("Failed to lock statement: {}", e)))?;
+
+    let sql = sql_guard.as_ref().ok_or(DuckyError::StatementFinalized)?;
+
+    let connection = stmt
+        .connection
+        .connection
+        .lock()
+        .map_err(|e| DuckyError::DatabaseError(format!("Failed to lock connection: {}", e)))?;
+
+    let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+    for term in params_list {
+        let param = term_to_duckdb_param(term)?;
+        params.push(param);
+    }
+
+    let param_refs: Vec<&dyn ToSql> = params.iter().map(|p| p.as_ref()).collect();
+
+    execute_statement_columns(env, &connection, sql, param_refs.as_slice())
+}
+
 /// Finalizes a prepared statement, invalidating it for further use.
 ///
 /// Clears the stored SQL so any subsequent execute_prepared calls will
@@ -345,6 +378,32 @@ fn execute_query<'a>(
     let param_refs: Vec<&dyn ToSql> = params.iter().map(|p| p.as_ref()).collect();
 
     execute_statement(env, &connection, &sql, param_refs.as_slice())
+}
+
+/// Executes a SQL query with optional parameter binding and returns columns.
+#[rustler::nif(schedule = "DirtyCpu")]
+fn execute_query_columns<'a>(
+    env: Env<'a>,
+    conn: ResourceArc<ConnectionResource>,
+    sql: String,
+    params_list: Vec<Term<'a>>,
+) -> Result<Vec<(String, Vec<Term<'a>>)>, DuckyError> {
+    use duckdb::types::ToSql;
+
+    let connection = conn
+        .connection
+        .lock()
+        .map_err(|e| DuckyError::DatabaseError(format!("Failed to lock connection: {}", e)))?;
+
+    let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+    for term in params_list {
+        let param = term_to_duckdb_param(term)?;
+        params.push(param);
+    }
+
+    let param_refs: Vec<&dyn ToSql> = params.iter().map(|p| p.as_ref()).collect();
+
+    execute_statement_columns(env, &connection, &sql, param_refs.as_slice())
 }
 
 /// Converts Arrow TimeUnit to DuckDB TimeUnit.
@@ -881,6 +940,103 @@ fn value_to_string(value: ValueRef<'_>) -> String {
     }
 }
 
+/// Extracts bare SQL keywords for statement classification.
+///
+/// This intentionally skips comments, string literals, and quoted identifiers
+/// so words like `RETURNING` only affect control flow when they are actual SQL
+/// keywords. It is a focused lexer, not a full SQL parser.
+fn sql_keywords(sql: &str) -> Vec<String> {
+    let bytes = sql.as_bytes();
+    let mut keywords = Vec::new();
+    let mut idx = 0;
+
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b if b.is_ascii_whitespace() => idx += 1,
+            b'-' if bytes.get(idx + 1) == Some(&b'-') => {
+                idx += 2;
+                while idx < bytes.len() && bytes[idx] != b'\n' {
+                    idx += 1;
+                }
+            }
+            b'/' if bytes.get(idx + 1) == Some(&b'*') => {
+                idx += 2;
+                while idx + 1 < bytes.len() && !(bytes[idx] == b'*' && bytes[idx + 1] == b'/') {
+                    idx += 1;
+                }
+                idx = (idx + 2).min(bytes.len());
+            }
+            b'\'' => {
+                idx += 1;
+                while idx < bytes.len() {
+                    if bytes[idx] == b'\'' {
+                        idx += 1;
+                        if bytes.get(idx) == Some(&b'\'') {
+                            idx += 1;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        idx += 1;
+                    }
+                }
+            }
+            b'"' | b'`' => {
+                let quote = bytes[idx];
+                idx += 1;
+                while idx < bytes.len() {
+                    if bytes[idx] == quote {
+                        idx += 1;
+                        if bytes.get(idx) == Some(&quote) {
+                            idx += 1;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        idx += 1;
+                    }
+                }
+            }
+            b if b.is_ascii_alphabetic() || b == b'_' => {
+                let start = idx;
+                idx += 1;
+                while idx < bytes.len()
+                    && (bytes[idx].is_ascii_alphanumeric() || bytes[idx] == b'_')
+                {
+                    idx += 1;
+                }
+                keywords.push(sql[start..idx].to_ascii_uppercase());
+            }
+            _ => idx += 1,
+        }
+    }
+
+    keywords
+}
+
+/// Classifies whether the column-oriented API should read an Arrow result.
+///
+/// DuckDB's Arrow path returns a synthetic `Count` column for plain DML, while
+/// the row API treats DDL/DML as empty results. Classifying first lets the two
+/// APIs keep the same non-result behavior without dropping legitimate result
+/// columns named `Count`.
+fn is_result_returning_statement(sql: &str) -> bool {
+    let keywords = sql_keywords(sql);
+    let Some(first_keyword) = keywords.first().map(String::as_str) else {
+        return true;
+    };
+
+    match first_keyword {
+        "SELECT" | "WITH" | "VALUES" | "SHOW" | "DESCRIBE" | "EXPLAIN" | "SUMMARIZE" | "PRAGMA"
+        | "CALL" | "FROM" => true,
+        "INSERT" | "UPDATE" | "DELETE" | "MERGE" => keywords.iter().any(|k| k == "RETURNING"),
+        "CREATE" | "DROP" | "ALTER" | "COPY" | "ANALYZE" | "SET" | "RESET" | "LOAD" | "INSTALL"
+        | "ATTACH" | "DETACH" | "VACUUM" | "BEGIN" | "COMMIT" | "ROLLBACK" | "TRUNCATE" | "USE"
+        | "EXPORT" | "IMPORT" => false,
+        _ => true,
+    }
+}
+
 /// Core statement execution logic for all queries.
 fn execute_statement<'a>(
     env: Env<'a>,
@@ -926,6 +1082,66 @@ fn execute_statement<'a>(
             // Not a query, try executing as DDL/DML statement
             stmt.execute(params)?;
             Ok((Vec::new(), Vec::new()))
+        }
+    }
+}
+
+/// Core statement execution logic for column-oriented queries.
+fn execute_statement_columns<'a>(
+    env: Env<'a>,
+    connection: &DuckDBConnection,
+    sql: &str,
+    params: &[&dyn duckdb::types::ToSql],
+) -> Result<Vec<(String, Vec<Term<'a>>)>, DuckyError> {
+    let mut stmt = connection.prepare(sql)?;
+
+    // Avoid DuckDB's synthetic Arrow `Count` result for non-result statements.
+    if !is_result_returning_statement(sql) {
+        stmt.execute(params)?;
+        return Ok(Vec::new());
+    }
+
+    match stmt.query_arrow(params) {
+        Ok(mut batches) => {
+            let schema = batches.get_schema();
+            let mut columns: Vec<(String, Vec<Term<'a>>)> = schema
+                .fields()
+                .iter()
+                .map(|field| (field.name().to_string(), Vec::new()))
+                .collect();
+
+            for batch in batches.by_ref() {
+                for column_idx in 0..batch.num_columns() {
+                    let array = batch.column(column_idx);
+                    for row_idx in 0..batch.num_rows() {
+                        let term = if array.is_null(row_idx) {
+                            atoms::null().encode(env)
+                        } else {
+                            let value =
+                                arrow_element_to_value_ref(array, row_idx).map_err(|e| {
+                                    DuckyError::DatabaseError(format!(
+                                        "Failed to convert column value: {}",
+                                        e
+                                    ))
+                                })?;
+                            value_to_term(env, value).map_err(|_| {
+                                DuckyError::DatabaseError(
+                                    "Failed to convert column value".to_string(),
+                                )
+                            })?
+                        };
+                        if let Some((_, values)) = columns.get_mut(column_idx) {
+                            values.push(term);
+                        }
+                    }
+                }
+            }
+
+            Ok(columns)
+        }
+        Err(_) => {
+            stmt.execute(params)?;
+            Ok(Vec::new())
         }
     }
 }

--- a/src/ducky.gleam
+++ b/src/ducky.gleam
@@ -97,6 +97,16 @@ pub type DataFrame {
   DataFrame(columns: List(String), rows: List(Row))
 }
 
+/// A single column from a column-oriented query result.
+pub type Column {
+  Column(name: String, values: List(Value))
+}
+
+/// A complete column-oriented query result.
+pub type ColumnDataFrame {
+  ColumnDataFrame(columns: List(Column))
+}
+
 /// An opaque connection to a DuckDB database.
 pub opaque type Connection {
   Connection(internal: connection.Connection)
@@ -251,6 +261,20 @@ pub fn query(conn: Connection, sql: String) -> Result(DataFrame, Error) {
   |> result.try(decode_dataframe)
 }
 
+/// Executes a SQL query and returns column-oriented results.
+///
+/// This uses DuckDB's Arrow result path in the native layer and returns each
+/// result column with its values. Existing row-oriented queries should continue
+/// to use `query`.
+pub fn query_columns(
+  conn: Connection,
+  sql: String,
+) -> Result(ColumnDataFrame, Error) {
+  ffi.execute_query_columns(connection.native(conn.internal), sql, [])
+  |> result.map_error(decode_nif_error)
+  |> result.try(decode_column_dataframe)
+}
+
 /// Executes a parameterized SQL query with bound parameters to prevent SQL injection.
 ///
 /// ## Examples
@@ -283,6 +307,23 @@ pub fn query_params(
   ffi.execute_query(connection.native(conn.internal), sql, dynamic_params)
   |> result.map_error(decode_nif_error)
   |> result.try(decode_dataframe)
+}
+
+/// Executes a parameterized SQL query and returns column-oriented results.
+pub fn query_params_columns(
+  conn: Connection,
+  sql: String,
+  params: List(Value),
+) -> Result(ColumnDataFrame, Error) {
+  use dynamic_params <- result.try(list.try_map(params, value_to_dynamic))
+
+  ffi.execute_query_columns(
+    connection.native(conn.internal),
+    sql,
+    dynamic_params,
+  )
+  |> result.map_error(decode_nif_error)
+  |> result.try(decode_column_dataframe)
 }
 
 /// Prepares a SQL statement for repeated execution.
@@ -322,12 +363,27 @@ pub fn prepare(conn: Connection, sql: String) -> Result(Statement, Error) {
 /// let assert Ok(result) = execute(stmt, [int(18)])
 /// // result.rows contains matching users
 /// ```
-pub fn execute(stmt: Statement, params: List(Value)) -> Result(DataFrame, Error) {
+pub fn execute(
+  stmt: Statement,
+  params: List(Value),
+) -> Result(DataFrame, Error) {
   use dynamic_params <- result.try(list.try_map(params, value_to_dynamic))
 
   ffi.execute_prepared(stmt.native, dynamic_params)
   |> result.map_error(decode_nif_error)
   |> result.try(decode_dataframe)
+}
+
+/// Executes a prepared statement and returns column-oriented results.
+pub fn execute_columns(
+  stmt: Statement,
+  params: List(Value),
+) -> Result(ColumnDataFrame, Error) {
+  use dynamic_params <- result.try(list.try_map(params, value_to_dynamic))
+
+  ffi.execute_prepared_columns(stmt.native, dynamic_params)
+  |> result.map_error(decode_nif_error)
+  |> result.try(decode_column_dataframe)
 }
 
 /// Finalizes a prepared statement, releasing its resources.
@@ -583,6 +639,20 @@ fn decode_dataframe(
     }),
   )
   Ok(DataFrame(columns: columns, rows: decoded_rows))
+}
+
+/// Decodes raw NIF column result into a ColumnDataFrame.
+fn decode_column_dataframe(
+  raw: List(#(String, List(dynamic.Dynamic))),
+) -> Result(ColumnDataFrame, Error) {
+  use decoded_columns <- result.try(
+    list.try_map(raw, fn(column) {
+      let #(name, values) = column
+      use decoded_values <- result.map(list.try_map(values, decode_value))
+      Column(name: name, values: decoded_values)
+    }),
+  )
+  Ok(ColumnDataFrame(columns: decoded_columns))
 }
 
 /// Decodes a dynamic value from the NIF into a typed Value.

--- a/src/ducky/internal/ffi.gleam
+++ b/src/ducky/internal/ffi.gleam
@@ -34,6 +34,16 @@ pub fn execute_query(
   params: List(Dynamic),
 ) -> Result(#(List(String), List(List(Dynamic))), Dynamic)
 
+/// Executes a SQL query and returns column-oriented results.
+///
+/// Returns a list of {column_name, values} pairs.
+@external(erlang, "ducky_nif", "execute_query_columns")
+pub fn execute_query_columns(
+  conn: NativeConnection,
+  sql: String,
+  params: List(Dynamic),
+) -> Result(List(#(String, List(Dynamic))), Dynamic)
+
 /// Prepares a SQL statement for repeated execution.
 ///
 /// Validates the SQL and returns a statement handle that can be
@@ -52,6 +62,13 @@ pub fn execute_prepared(
   stmt: NativeStatement,
   params: List(Dynamic),
 ) -> Result(#(List(String), List(List(Dynamic))), Dynamic)
+
+/// Executes a prepared statement and returns column-oriented results.
+@external(erlang, "ducky_nif", "execute_prepared_columns")
+pub fn execute_prepared_columns(
+  stmt: NativeStatement,
+  params: List(Dynamic),
+) -> Result(List(#(String, List(Dynamic))), Dynamic)
 
 /// Finalizes a prepared statement, releasing resources.
 @external(erlang, "ducky_nif", "finalize")

--- a/src/erlang/ducky_nif.erl
+++ b/src/erlang/ducky_nif.erl
@@ -1,6 +1,7 @@
 -module(ducky_nif).
--export([connect/1, close/1, execute_query/3, prepare/2, execute_prepared/2, finalize/1,
-         append_rows/3, health_check/0]).
+-export([connect/1, close/1, execute_query/3, execute_query_columns/3, prepare/2,
+         execute_prepared/2, execute_prepared_columns/2, finalize/1, append_rows/3,
+         health_check/0]).
 -on_load(init/0).
 
 init() ->
@@ -48,10 +49,16 @@ close(_Connection) ->
 execute_query(_Connection, _Sql, _Params) ->
     erlang:nif_error(nif_not_loaded).
 
+execute_query_columns(_Connection, _Sql, _Params) ->
+    erlang:nif_error(nif_not_loaded).
+
 prepare(_Connection, _Sql) ->
     erlang:nif_error(nif_not_loaded).
 
 execute_prepared(_Statement, _Params) ->
+    erlang:nif_error(nif_not_loaded).
+
+execute_prepared_columns(_Statement, _Params) ->
     erlang:nif_error(nif_not_loaded).
 
 finalize(_Statement) ->

--- a/test/ducky_test.gleam
+++ b/test/ducky_test.gleam
@@ -219,6 +219,119 @@ pub fn query_insert_and_select_test() {
   |> should.equal(2)
 }
 
+pub fn query_columns_select_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+
+  let assert Ok(result) =
+    ducky.query_columns(
+      conn,
+      "SELECT * FROM (VALUES (1, 'Alice'), (2, 'Bob')) AS users(id, name)",
+    )
+
+  let ducky.ColumnDataFrame(columns) = result
+  let assert [
+    ducky.Column("id", [ducky.Integer(1), ducky.Integer(2)]),
+    ducky.Column("name", [ducky.Text("Alice"), ducky.Text("Bob")]),
+  ] = columns
+}
+
+pub fn query_and_query_columns_return_different_shapes_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+  let sql = "SELECT * FROM (VALUES (1, 'Alice'), (2, 'Bob')) AS users(id, name)"
+
+  let assert Ok(row_result) = ducky.query(conn, sql)
+  let assert Ok(column_result) = ducky.query_columns(conn, sql)
+
+  row_result.columns |> should.equal(["id", "name"])
+  let assert [
+    ducky.Row([ducky.Integer(1), ducky.Text("Alice")]),
+    ducky.Row([ducky.Integer(2), ducky.Text("Bob")]),
+  ] = row_result.rows
+
+  let ducky.ColumnDataFrame(columns) = column_result
+  let assert [
+    ducky.Column("id", [ducky.Integer(1), ducky.Integer(2)]),
+    ducky.Column("name", [ducky.Text("Alice"), ducky.Text("Bob")]),
+  ] = columns
+}
+
+pub fn query_columns_exposes_whole_column_values_directly_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+  let sql =
+    "SELECT * FROM (VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Eve')) AS users(id, name)"
+
+  let assert Ok(row_result) = ducky.query(conn, sql)
+  let row_ids =
+    row_result.rows
+    |> list.map(fn(row) {
+      case ducky.get(row, 0) {
+        option.Some(ducky.Integer(id)) -> id
+        _ -> -1
+      }
+    })
+
+  let assert Ok(column_result) = ducky.query_columns(conn, sql)
+  let ducky.ColumnDataFrame(columns) = column_result
+  let assert [ducky.Column("id", column_ids), ducky.Column("name", _)] = columns
+
+  row_ids |> should.equal([1, 2, 3])
+  column_ids
+  |> should.equal([ducky.Integer(1), ducky.Integer(2), ducky.Integer(3)])
+}
+
+pub fn query_columns_empty_select_keeps_columns_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+  let assert Ok(_) =
+    ducky.query(conn, "CREATE TABLE users (id INT, name VARCHAR)")
+
+  let assert Ok(result) = ducky.query_columns(conn, "SELECT * FROM users")
+
+  let ducky.ColumnDataFrame(columns) = result
+  let assert [ducky.Column("id", []), ducky.Column("name", [])] = columns
+}
+
+pub fn query_columns_empty_count_select_keeps_column_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+
+  let assert Ok(result) =
+    ducky.query_columns(conn, "SELECT 1 AS Count WHERE false")
+
+  let ducky.ColumnDataFrame(columns) = result
+  let assert [ducky.Column("Count", [])] = columns
+}
+
+pub fn query_columns_non_result_statement_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+
+  let assert Ok(result) = ducky.query_columns(conn, "CREATE TABLE t (id INT)")
+
+  let ducky.ColumnDataFrame(columns) = result
+  columns |> should.equal([])
+}
+
+pub fn query_columns_insert_statement_returns_empty_columns_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+  let assert Ok(_) = ducky.query(conn, "CREATE TABLE t (id INT)")
+
+  let assert Ok(result) =
+    ducky.query_columns(conn, "INSERT INTO t VALUES (1), (2)")
+
+  let ducky.ColumnDataFrame(columns) = result
+  columns |> should.equal([])
+}
+
+pub fn query_columns_insert_returning_keeps_columns_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+  let assert Ok(_) = ducky.query(conn, "CREATE TABLE t (id INT)")
+
+  let assert Ok(result) =
+    ducky.query_columns(conn, "INSERT INTO t VALUES (1), (2) RETURNING id")
+
+  let ducky.ColumnDataFrame(columns) = result
+  let assert [ducky.Column("id", [ducky.Integer(1), ducky.Integer(2)])] =
+    columns
+}
+
 pub fn query_params_select_test() {
   let assert Ok(conn) = ducky.connect(":memory:")
   let assert Ok(_) =
@@ -242,6 +355,26 @@ pub fn query_params_select_test() {
   result.rows
   |> list.length
   |> should.equal(2)
+}
+
+pub fn query_params_columns_select_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+
+  let assert Ok(result) =
+    ducky.query_params_columns(
+      conn,
+      "SELECT ?::INTEGER AS id, ?::VARCHAR AS name",
+      [
+        ducky.Integer(42),
+        ducky.Text("Eve"),
+      ],
+    )
+
+  let ducky.ColumnDataFrame(columns) = result
+  let assert [
+    ducky.Column("id", [ducky.Integer(42)]),
+    ducky.Column("name", [ducky.Text("Eve")]),
+  ] = columns
 }
 
 pub fn query_params_insert_test() {
@@ -1269,6 +1402,34 @@ pub fn execute_prepared_select_test() {
   result.columns |> should.equal(["name"])
   let assert [ducky.Row([ducky.Text(name)])] = result.rows
   name |> should.equal("Alice")
+}
+
+pub fn execute_prepared_columns_select_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+  let assert Ok(_) =
+    ducky.query(conn, "CREATE TABLE users (id INT, name VARCHAR)")
+  let assert Ok(_) = ducky.query(conn, "INSERT INTO users VALUES (1, 'Alice')")
+  let assert Ok(stmt) =
+    ducky.prepare(conn, "SELECT name FROM users WHERE id = ?")
+
+  let assert Ok(result) = ducky.execute_columns(stmt, [ducky.Integer(1)])
+
+  let ducky.ColumnDataFrame(columns) = result
+  let assert [ducky.Column("name", [ducky.Text(name)])] = columns
+  name |> should.equal("Alice")
+}
+
+pub fn execute_prepared_columns_insert_statement_returns_empty_columns_test() {
+  let assert Ok(conn) = ducky.connect(":memory:")
+  let assert Ok(_) =
+    ducky.query(conn, "CREATE TABLE users (id INT, name VARCHAR)")
+  let assert Ok(stmt) = ducky.prepare(conn, "INSERT INTO users VALUES (?, ?)")
+
+  let assert Ok(result) =
+    ducky.execute_columns(stmt, [ducky.Integer(1), ducky.Text("Alice")])
+
+  let ducky.ColumnDataFrame(columns) = result
+  columns |> should.equal([])
 }
 
 pub fn execute_prepared_insert_test() {


### PR DESCRIPTION
Adds a column-oriented query API for callers that want to work with whole result columns directly, while keeping the existing row-oriented API unchanged.

This PR is split into two commits:

1. Expand Arrow value conversion coverage
2. Add column-oriented query API

## 1. Expand Arrow value conversion coverage

Updates the native Arrow-to-`ValueRef` conversion path so Arrow-backed results can decode the existing `ducky.Value` result types more consistently.

This includes support for:
- null handling at the Arrow element conversion layer
- large strings and large binaries
- decimal values
- large lists
- dictionary-backed enum values
- additional timestamp units
- maps
- fixed-size arrays
- unions

This also adds `rust_decimal` as a direct dependency because decimal Arrow values are converted with `rust_decimal::Decimal::from_i128_with_scale`.

## 2. Add column-oriented query API

Adds public Gleam APIs:

- `query_columns`
- `query_params_columns`
- `execute_columns`

Example:

```gleam
let assert Ok(result) =
  ducky.query_columns(
    conn,
    "SELECT id, name FROM users ORDER BY id",
  )

let ducky.ColumnDataFrame(columns) = result

let assert [
  ducky.Column("id", [
    ducky.Integer(1),
    ducky.Integer(2),
  ]),
  ducky.Column("name", [
    ducky.Text("Alice"),
    ducky.Text("Bob"),
  ]),
] = columns
```

## 3. DDL/DML behavior
The column-oriented API keeps behavior aligned with the existing row-oriented API:

- plain DDL/DML statements return empty columns
- result-returning DML such as INSERT ... RETURNING returns columns
- legitimate empty result columns, including a column named Count, are preserved

The native layer classifies statement keywords before using DuckDB’s Arrow result path to avoid accidentally exposing DuckDB’s synthetic Count column for non-result statements.

## 4. Testing
Added tests covering:

1. basic column-oriented selects
2. row-oriented vs column-oriented result shapes
3. direct whole-column access
4. empty selects preserving column metadata
5. empty result column named Count
6. DDL/DML returning empty columns
7. INSERT ... RETURNING
8. parameterized column queries
9. prepared statement column queries
10. prepared statement insert returning empty columns